### PR TITLE
Renaming Pseudopotential to UPFDict and enhancing the docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-dev
+current_version = 0.1.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.1.0-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ graft tests
 prune scripts
 prune notebooks
 prune tests/.pytest_cache
+prune tests/sssp
 
 prune docs/build
 prune docs/source/api

--- a/README.md
+++ b/README.md
@@ -65,14 +65,12 @@ $ upf_tools to-input /path/to/pseudo.upf > pseudo.in
 
 ## 🚀 Installation
 
-<!-- Uncomment this section after your first ``tox -e finish``
 The most recent release can be installed from
 [PyPI](https://pypi.org/project/upf_tools/) with:
 
 ```shell
 $ pip install upf_tools
 ```
--->
 
 The most recent code and data can be installed directly from GitHub with:
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,6 +1,6 @@
 Command Line Interface
 ======================
-upf_tools automatically installs the command :code:`upf_tools`. See
+The ``upf_tools`` package automatically installs the command :code:`upf_tools`. See
 :code:`upf_tools --help` for usage details.
 
 .. click:: upf_tools.cli:main

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = f"{date.today().year}, Edward Linscott"
 author = "Edward Linscott"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.0.1"
+release = "0.1.0-dev"
 
 # The short X.Y version.
 parsed_version = re.match(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = f"{date.today().year}, Edward Linscott"
 author = "Edward Linscott"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.1.0-dev"
+release = "0.1.0"
 
 # The short X.Y version.
 parsed_version = re.match(

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,35 +1,6 @@
 upf-tools |release| Documentation
 =================================
 
-Cookiecutter
-------------
-This package was created with the `cookiecutter <https://github.com/cookiecutter/cookiecutter>`_
-package using `cookiecutter-snekpack <https://github.com/cthoyt/cookiecutter-snekpack>`_ template.
-It comes with the following:
-
-- Standard `src/` layout
-- Declarative setup with `setup.cfg` and `pyproject.toml`
-- Reproducible tests with `pytest` and `tox`
-- A command line interface with `click`
-- A vanity CLI via python entrypoints
-- Version management with `bumpversion`
-- Documentation build with `sphinx`
-- Testing of code quality with `flake8` in `tox`
-- Testing of documentation coverage with `docstr-coverage` in `tox`
-- Testing of documentation format and build in `tox`
-- Testing of package metadata completeness with `pyroma` in `tox`
-- Testing of MANIFEST correctness with `check-manifest` in `tox`
-- Testing of optional static typing with `mypy` in `tox`
-- A `py.typed` file so other packages can use your type hints
-- Automated running of tests on each push with GitHub Actions
-- Configuration for `ReadTheDocs <https://readthedocs.org/>`_
-- A good base `.gitignore` generated from `gitignore.io <https://gitignore.io>`_.
-- A pre-formatted README with badges
-- A pre-formatted LICENSE file with the MIT License (you can change this to whatever you want, though)
-- A pre-formatted CONTRIBUTING guide
-- Automatic tool for releasing to PyPI with ``tox -e finish``
-- A copy of the `Contributor Covenant <https://www.contributor-covenant.org>`_ as a basic code of conduct
-
 Table of Contents
 -----------------
 .. toctree::
@@ -46,3 +17,8 @@ Indices and Tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+Cookiecutter
+------------
+This package was created with the `cookiecutter <https://github.com/cookiecutter/cookiecutter>`_
+package using `cookiecutter-snekpack <https://github.com/cthoyt/cookiecutter-snekpack>`_ template.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,4 +1,4 @@
 Usage
 =====
-.. automodule:: upf_tools.api
+.. automodule:: upf_tools.pseudopotential
     :members:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,4 +1,7 @@
 Usage
 =====
-.. automodule:: upf_tools.pseudopotential
+
+The :class:`UPFDict` class is the heart of ``upf-tools``. It is an ordered dictionary with a few extra functionalities.
+
+.. autoclass:: upf_tools.UPFDict
     :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ##########################
 [metadata]
 name = upf_tools
-version = 0.0.1
+version = 0.1.0-dev
 description = Tools for handling .upf (Unified Pseudopotential Format) files
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,6 +138,8 @@ strictness = short
 #########################
 [flake8]
 ignore =
+    # __init__ does not need a docstring
+    D107
     # assert (used in tests)
     S101
     # pickle

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,13 +138,18 @@ strictness = short
 #########################
 [flake8]
 ignore =
-    S101 # assert (used in tests)
-    S301 # pickle
-    S403 # pickle
+    # assert (used in tests)
+    S101
+    # pickle
+    S301
+    # pickle
+    S403
     S404
     S603
-    W503 # Line break before binary operator (flake8 is wrong)
-    E203  # whitespace before ':'
+    # Line break before binary operator (flake8 is wrong)
+    W503
+    # whitespace before ':'
+    E203
 exclude =
     .tox,
     .git,

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ##########################
 [metadata]
 name = upf_tools
-version = 0.1.0-dev
+version = 0.1.0
 description = Tools for handling .upf (Unified Pseudopotential Format) files
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/upf_tools/__init__.py
+++ b/src/upf_tools/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-"""Tools for handling .upf (Unified Pseudopotential Format) files."""
+"""Tools for handling .upf (Unified UPFDict Format) files."""
 
-from .api import *  # noqa
-from .pseudopotential import Pseudopotential  # noqa: F401
+from .upfdict import UPFDict  # noqa: F401

--- a/src/upf_tools/cli.py
+++ b/src/upf_tools/cli.py
@@ -17,7 +17,7 @@ import logging
 
 import click
 
-from upf_tools import Pseudopotential
+from upf_tools import UPFDict
 
 __all__ = [
     "main",
@@ -41,7 +41,7 @@ def to_input(filename):
     :param filename: the name of the .upf file
     :type filename: str
     """
-    psp = Pseudopotential.from_upf(filename)
+    psp = UPFDict.from_upf(filename)
     inp = psp.to_input()
     click.echo(inp)
 
@@ -54,7 +54,7 @@ def to_dat(filename):
     :param filename: the name of the .upf file
     :type filename: str
     """
-    psp = Pseudopotential.from_upf(filename)
+    psp = UPFDict.from_upf(filename)
     dat = psp.to_dat()
     click.echo(dat)
 

--- a/src/upf_tools/cli.py
+++ b/src/upf_tools/cli.py
@@ -39,6 +39,7 @@ def to_input(filename):
     Extract an input file from a pseudopotential.
 
     :param filename: the name of the .upf file
+    :type filename: str
     """
     psp = Pseudopotential.from_upf(filename)
     inp = psp.to_input()
@@ -51,6 +52,7 @@ def to_dat(filename):
     """Extract a dat file from a pseudopotential.
 
     :param filename: the name of the .upf file
+    :type filename: str
     """
     psp = Pseudopotential.from_upf(filename)
     dat = psp.to_dat()

--- a/src/upf_tools/upfdict.py
+++ b/src/upf_tools/upfdict.py
@@ -23,6 +23,15 @@ class UPFDict(OrderedDict):
         from upf_tools import UPFDict
         psp = UPFDict.from_upf(/path/to/file.upf)
 
+    instead of direct instantiation.
+
+    :param version:  the UPF version number
+    :type version:   str, Version
+    :param filename: the name of the UPF file
+    :param args:     arguments used to construct the dictionary of UPF entries
+                     (``header``, ``mesh``, ``local``, ...)
+    :param kwargs:   keyword arguments used to construct the dictionary of UPF entries
+
     """
 
     def __init__(
@@ -32,15 +41,6 @@ class UPFDict(OrderedDict):
         *args,
         **kwargs,
     ):
-        """
-        :param version:  the UPF version number
-        :type version:   str, Version
-        :param filename: the name of the UPF file
-        :param args:     arguments used to construct the dictionary of UPF entries
-                         (``header``, ``mesh``, ``local``, ...)
-        :param kwargs:   keyword arguments used to construct the dictionary of UPF entries
-        """
-
         super().__init__(*args, **kwargs)
         self.filename = filename  # type: ignore
         self.version = version
@@ -107,8 +107,15 @@ class UPFDict(OrderedDict):
         return psp
 
     def to_dat(self) -> str:
-        """Generate a ``.dat`` file (containing projectors that ``wannier90.x`` can read) from a :class:`UPFDict`
-        object."""
+        """Generate a ``.dat`` file from a :class:`UPFDict` object.
+
+        These files contain projectors that ``wannier90.x`` can read.
+
+        :raises ValueError: The pseudopotential does not contain the pseudo-wavefunctions necessary to generate
+            a ``.dat`` file
+
+        :returns: the contents of a ``.dat`` file
+        """
         # Fetch the r-mesh
         rmesh = self["mesh"]["r"]
 

--- a/src/upf_tools/upfdict.py
+++ b/src/upf_tools/upfdict.py
@@ -1,4 +1,4 @@
-"""Module containing the `Pseudopotential` class, the core class of upf-tools."""
+"""Module containing the :class:`UPFDict` class, the heart of ``upf-tools``."""
 
 from __future__ import annotations
 
@@ -14,8 +14,16 @@ from .v1 import upfv1contents_to_dict
 from .v2 import upfv2contents_to_dict
 
 
-class Pseudopotential(OrderedDict):
-    """Class that contains all of the information of a UPF pseudopotential file."""
+class UPFDict(OrderedDict):
+    """Class that contains all of the information of a UPF pseudopotential file.
+
+    Note that it will usually be more convenient to create a :class:`UPFDict` object using
+    the class method ``UPFDict.from_upf(...)`` i.e. ::
+
+        from upf_tools import UPFDict
+        psp = UPFDict.from_upf(/path/to/file.upf)
+
+    """
 
     def __init__(
         self,
@@ -25,30 +33,21 @@ class Pseudopotential(OrderedDict):
         **kwargs,
     ):
         """
-        Initialise a :class:`Pseudopotential` object.
-
-        Note that it will usually be more convenient to create a :class:`Pseudopotential` object using
-        the class method `Pseudopotential.from_upf(...)` i.e.
-
-        ``` python
-        from upf_tools import Pseudopotential
-        psp = Pseudopotential.from_upf(/path/to/file.upf)
-        ```
-
         :param version:  the UPF version number
         :type version:   str, Version
         :param filename: the name of the UPF file
-        :param args:    args used to construct the dictionary of UPF entries ('header', 'mesh', 'local', ...)
-        :param kwargs: kwargs used to construct the dictionary of UPF entries
+        :param args:     arguments used to construct the dictionary of UPF entries (``header``, ``mesh``, ``local``, ...)
+        :param kwargs:   keyword arguments used to construct the dictionary of UPF entries
         """
+
         super().__init__(*args, **kwargs)
         self.filename = filename  # type: ignore
         self.version = version
 
     def __repr__(self, *args, **kwargs) -> str:
-        """Provide a minimal repr of a Pseudopotential."""
+        """Provide a minimal representation of a UPFDict."""
         return (
-            f'Pseudopotential(keys=({", ".join([k for k in self.keys()])}), '
+            f'UPFDict(keys=({", ".join([k for k in self.keys()])}), '
             f"filename={self.filename}, version={self.version}))"
         )
 
@@ -77,8 +76,8 @@ class Pseudopotential(OrderedDict):
         self._version = value
 
     @classmethod
-    def from_str(cls, string: str) -> Pseudopotential:
-        """Create a :class:`Pseudopotential` object from a string (typically the contents of a upf file)."""
+    def from_str(cls, string: str) -> UPFDict:
+        """Create a :class:`UPFDict` object from a string (typically the contents of a ``.upf`` file)."""
         # Fetch the version number
         version = get_version_number(string)
 
@@ -91,8 +90,8 @@ class Pseudopotential(OrderedDict):
         return cls(version, **dct)
 
     @classmethod
-    def from_upf(cls, filename: Union[Path, str]) -> Pseudopotential:
-        """Create a :class:`Pseudopotential` object from a `.upf` file."""
+    def from_upf(cls, filename: Union[Path, str]) -> UPFDict:
+        """Create a :class:`UPFDict` object from a ``.upf`` file."""
         # Sanitise input
         filename = filename if isinstance(filename, Path) else Path(filename)
 
@@ -107,7 +106,7 @@ class Pseudopotential(OrderedDict):
         return psp
 
     def to_dat(self) -> str:
-        """Generate a .dat file (containing projectors that wannier90.x can read) from a Pseudopotential object."""
+        """Generate a ``.dat`` file (containing projectors that ``wannier90.x`` can read) from a :class:`UPFDict` object."""
         # Fetch the r-mesh
         rmesh = self["mesh"]["r"]
 

--- a/src/upf_tools/upfdict.py
+++ b/src/upf_tools/upfdict.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from packaging.version import Version
@@ -36,7 +36,8 @@ class UPFDict(OrderedDict):
         :param version:  the UPF version number
         :type version:   str, Version
         :param filename: the name of the UPF file
-        :param args:     arguments used to construct the dictionary of UPF entries (``header``, ``mesh``, ``local``, ...)
+        :param args:     arguments used to construct the dictionary of UPF entries
+                         (``header``, ``mesh``, ``local``, ...)
         :param kwargs:   keyword arguments used to construct the dictionary of UPF entries
         """
 
@@ -106,7 +107,8 @@ class UPFDict(OrderedDict):
         return psp
 
     def to_dat(self) -> str:
-        """Generate a ``.dat`` file (containing projectors that ``wannier90.x`` can read) from a :class:`UPFDict` object."""
+        """Generate a ``.dat`` file (containing projectors that ``wannier90.x`` can read) from a :class:`UPFDict`
+        object."""
         # Fetch the r-mesh
         rmesh = self["mesh"]["r"]
 

--- a/src/upf_tools/utils.py
+++ b/src/upf_tools/utils.py
@@ -1,0 +1,24 @@
+"""Miscellaneous utilities for upf-tools."""
+
+import re
+import warnings
+
+from packaging.version import Version
+
+REGEX_UPF_VERSION = re.compile(
+    r"""
+    \s*<UPF\s+version\s*="
+    (?P<version>.*)">
+    """,
+    re.VERBOSE,
+)
+
+
+def get_version_number(string: str) -> Version:
+    """Extract the version number from the contents of a UPF file."""
+    match = REGEX_UPF_VERSION.search(string)
+    if match:
+        return Version(match.group("version"))
+    else:
+        warnings.warn(f"Could not determine the UPF version. Assuming v1.0.0")  # noqa
+        return Version("1.0.0")

--- a/src/upf_tools/version.py
+++ b/src/upf_tools/version.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.1.0-dev"
+VERSION = "0.1.0"
 
 
 def get_git_hash() -> str:

--- a/src/upf_tools/version.py
+++ b/src/upf_tools/version.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.0.1"
+VERSION = "0.1.0-dev"
 
 
 def get_git_hash() -> str:

--- a/tests/test_upfdict.py
+++ b/tests/test_upfdict.py
@@ -11,7 +11,7 @@ sssp = Path(__file__).parent / "sssp"
 
 @pytest.mark.parametrize("filename", [f for ext in ["upf", "UPF"] for f in sssp.glob(f"*.{ext}")])
 def test_from_upf(filename):
-    """Test creating a `UPFDict` object via the classmethod `from_upf`."""
+    """Test creating a :class:`UPFDict` object via the classmethod ``from_upf``."""
     psp = UPFDict.from_upf(filename)
     assert "header" in psp
     assert "z_valence" in psp["header"]
@@ -26,6 +26,6 @@ def test_from_upf(filename):
 
 @pytest.mark.parametrize("filename", [f for ext in ["upf", "UPF"] for f in sssp.glob(f"*.{ext}")])
 def test_to_dat(filename):
-    """Test generating a `.dat` file via `from_upf`"""
+    """Test generating a ``.dat`` file via ``from_upf``."""
     psp = UPFDict.from_upf(filename)
     psp.to_dat()

--- a/tests/test_upfdict.py
+++ b/tests/test_upfdict.py
@@ -1,18 +1,18 @@
-"""Testing the `Pseudopotential` class."""
+"""Testing the :class:`UPFDict` class."""
 
 from pathlib import Path
 
 import pytest
 
-from upf_tools import Pseudopotential
+from upf_tools import UPFDict
 
 sssp = Path(__file__).parent / "sssp"
 
 
 @pytest.mark.parametrize("filename", [f for ext in ["upf", "UPF"] for f in sssp.glob(f"*.{ext}")])
 def test_from_upf(filename):
-    """Tests creating a `Pseudopotential` object via the classmethod `from_upf`."""
-    psp = Pseudopotential.from_upf(filename)
+    """Test creating a `UPFDict` object via the classmethod `from_upf`."""
+    psp = UPFDict.from_upf(filename)
     assert "header" in psp
     assert "z_valence" in psp["header"]
     assert "number_of_proj" in psp["header"]
@@ -26,6 +26,6 @@ def test_from_upf(filename):
 
 @pytest.mark.parametrize("filename", [f for ext in ["upf", "UPF"] for f in sssp.glob(f"*.{ext}")])
 def test_to_dat(filename):
-    """Tests creating a `Pseudopotential` object via the classmethod `from_upf`."""
-    psp = Pseudopotential.from_upf(filename)
+    """Test generating a `.dat` file via `from_upf`"""
+    psp = UPFDict.from_upf(filename)
     psp.to_dat()

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,7 @@ skip_install = true
 deps =
     docstr-coverage
 commands =
-    docstr-coverage src/ tests/ --skip-private --skip-magic
+    docstr-coverage src/ tests/ --skip-private --skip-magic --skip-init
 description = Run the docstr-coverage tool to check documentation coverage
 
 [testenv:docs]


### PR DESCRIPTION
This PR...

- renames the `Pseudopotential` class as `UPFDict` (in order to stress the fact that the class is basically a fancy `Dict`
- adds documentation (mostly autogenerated)