### PR TITLE
Add `UPFDict.to_str` / `to_upf` for UPF v2 round-trip

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,9 +10,9 @@ sphinx:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.9"
+    python: "3"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,10 @@
 
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/source/conf.py
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,5 +14,5 @@ recursive-include docs/source *.png
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store *.gpickle
 
-include README.md LICENSE
+include README.md LICENSE uv.lock
 exclude tox.ini .bumpversion.cfg .readthedocs.yml .cruft.json CITATION.cff docker-compose.yml Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = ["py310", "py311", "py312", "py313", "py314"]
 
 [tool.isort]
 profile = "black"

--- a/src/upf_tools/upfdict.py
+++ b/src/upf_tools/upfdict.py
@@ -137,7 +137,7 @@ class UPFDict(OrderedDict):
         """Write this :class:`UPFDict` to ``filename`` in UPF v2 format.
 
         :param filename: destination path
-        :returns: the resolved :class:`Path` written to
+        :returns: the :class:`Path` written to
         """
         path = Path(filename) if not isinstance(filename, Path) else filename
         path.write_text(self.to_str(), encoding="utf-8")

--- a/src/upf_tools/upfdict.py
+++ b/src/upf_tools/upfdict.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 
 from .utils import get_version_number
 from .v1 import upfv1contents_to_dict
-from .v2 import upfv2contents_to_dict
+from .v2 import dict_to_upfv2, upfv2contents_to_dict
 
 
 class UPFDict(OrderedDict):
@@ -116,6 +116,32 @@ class UPFDict(OrderedDict):
         psp.filename = filename
 
         return psp
+
+    def to_str(self) -> str:
+        """Serialise this :class:`UPFDict` back to UPF text.
+
+        Currently only UPF v2 (the modern XML format) is supported on
+        write. Reading is unaffected; v1 files can still be loaded but
+        not written back out.
+
+        :raises NotImplementedError: if :attr:`version` is below 2.0.
+        :returns: the UPF file contents as a string
+        """
+        if self.version < Version("2.0.0"):
+            raise NotImplementedError(
+                "Writing UPF v1 is not yet supported; only v2 (XML) is implemented."
+            )
+        return dict_to_upfv2(self, version=str(self.version))
+
+    def to_upf(self, filename: Union[Path, str]) -> Path:
+        """Write this :class:`UPFDict` to ``filename`` in UPF v2 format.
+
+        :param filename: destination path
+        :returns: the resolved :class:`Path` written to
+        """
+        path = Path(filename) if not isinstance(filename, Path) else filename
+        path.write_text(self.to_str(), encoding="utf-8")
+        return path
 
     def to_dat(self) -> str:
         """Generate a ``.dat`` file from a :class:`UPFDict` object.

--- a/src/upf_tools/v2.py
+++ b/src/upf_tools/v2.py
@@ -36,9 +36,7 @@ def block_to_dict(element: ElementTree.Element) -> OrderedDict[str, Any]:
     :return: a (possibly nested) dict
     """
     result = {
-        k.lower(): sanitise(v)
-        for k, v in element.attrib.items()
-        if k not in ["type", "columns", "size"]
+        k.lower(): sanitise(v) for k, v in element.attrib.items() if k not in _ARRAY_ATTRS
     }
 
     # Manually adding n information if it is missing
@@ -99,7 +97,7 @@ def _format_array(arr: np.ndarray) -> str:
     """
     flat = np.asarray(arr).ravel()
     # 17 significant digits guarantees lossless float64 round-trip (IEEE 754).
-    parts = [f"{v: .17E}" for v in flat]
+    parts = [f"{v:.17E}" for v in flat]
     lines = [
         " ".join(parts[i : i + _DEFAULT_COLUMNS]) for i in range(0, len(parts), _DEFAULT_COLUMNS)
     ]

--- a/src/upf_tools/v2.py
+++ b/src/upf_tools/v2.py
@@ -3,13 +3,24 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Any
+from typing import Any, Mapping
 from xml.etree import ElementTree  # noqa
 
 import numpy as np
 from defusedxml.ElementTree import fromstring as defused_fromstring
 
 from upf_tools.utils import sanitise
+
+# Attributes that ``block_to_dict`` strips on read but that need to be
+# reconstructed on write. The convention used by Quantum ESPRESSO is to
+# always emit them for numeric arrays.
+_ARRAY_ATTRS = ("type", "size", "columns")
+_DEFAULT_COLUMNS = 4
+# Tags whose children are always emitted as ``.1``, ``.2``, ... numbered
+# elements when they appear as a list. The parser collapses these on
+# read; ``chi`` is special-cased there to always become a list even when
+# there is only one entry, so it is special-cased here too.
+_ALWAYS_LIST_AS_INDEXED = {"chi"}
 
 
 def block_to_dict(element: ElementTree.Element) -> OrderedDict[str, Any]:
@@ -70,3 +81,151 @@ def upfv2contents_to_dict(filecontents: str):
     dct = block_to_dict(root)
     dct.pop("version")
     return dct
+
+
+# ---------------------------------------------------------------------------
+# Writing v2 UPF
+# ---------------------------------------------------------------------------
+
+
+def _format_array(arr: np.ndarray) -> str:
+    """Format a numeric array as space-separated scientific notation.
+
+    The result is wrapped at ``_DEFAULT_COLUMNS`` values per line to
+    match the QE convention.
+    """
+    flat = np.asarray(arr).ravel()
+    # 17 significant digits guarantees lossless float64 round-trip (IEEE 754).
+    parts = [f"{v: .17E}" for v in flat]
+    lines = [
+        " ".join(parts[i : i + _DEFAULT_COLUMNS])
+        for i in range(0, len(parts), _DEFAULT_COLUMNS)
+    ]
+    return "\n" + "\n".join(lines) + "\n"
+
+
+def _attr_value(value: Any) -> str:
+    """Format a Python value as an XML attribute string."""
+    if isinstance(value, bool):
+        return "T" if value else "F"
+    if isinstance(value, float):
+        return f"{value:.17E}"
+    return str(value)
+
+
+def _set_array_attrs(elem: ElementTree.Element, arr: np.ndarray) -> None:
+    """Populate the ``type/size/columns`` attribs on a numeric-array element."""
+    elem.set("type", "real")
+    elem.set("size", str(arr.size))
+    elem.set("columns", str(_DEFAULT_COLUMNS))
+
+
+def _is_array_like(value: Any) -> bool:
+    return isinstance(value, np.ndarray)
+
+
+def _make_pp_tag(name: str, index: int | None = None) -> str:
+    """Convert a lower-case parser key back into a ``PP_<NAME>`` tag, optionally numbered."""
+    tag = f"PP_{name.upper()}"
+    if index is not None:
+        tag = f"{tag}.{index}"
+    return tag
+
+
+def _build_element(tag: str, value: Any) -> ElementTree.Element:
+    """Inverse of :func:`block_to_dict`: build an XML element from a parsed value.
+
+    The shape of *value* drives behaviour:
+
+    * ``np.ndarray`` -> bare numeric block with type/size/columns attribs
+    * ``str`` -> element whose ``text`` is the raw string
+    * ``Mapping`` -> attributes from non-``content`` keys; nested dicts/lists
+      become child elements; a ``content`` key (if present) becomes the text
+      of *this* element. Lists become numbered children.
+    """
+    elem = ElementTree.Element(tag)
+
+    if _is_array_like(value):
+        _set_array_attrs(elem, value)
+        elem.text = _format_array(value)
+        return elem
+
+    if isinstance(value, str):
+        # Wrap text content in newlines for readability (matches QE style).
+        elem.text = "\n" + value.rstrip("\n") + "\n"
+        return elem
+
+    if isinstance(value, Mapping):
+        # 1. Split the dict into (attribs, content, children).
+        content: Any = None
+        attribs: dict[str, Any] = {}
+        children: dict[str, Any] = {}
+        for k, v in value.items():
+            if k == "content":
+                content = v
+            elif _is_array_like(v) or isinstance(v, (Mapping, list)):
+                children[k] = v
+            else:
+                attribs[k] = v
+
+        # 2. Emit attribs.
+        for k, v in attribs.items():
+            elem.set(k, _attr_value(v))
+
+        # 3. Emit content (if present).
+        if content is not None:
+            if _is_array_like(content):
+                _set_array_attrs(elem, content)
+                elem.text = _format_array(content)
+            elif isinstance(content, str):
+                elem.text = "\n" + content.rstrip("\n") + "\n"
+            else:
+                elem.text = str(content)
+
+        # 4. Emit children. Lists become numbered children; lone dicts
+        #    use the bare PP_<NAME> tag. ``chi`` is always numbered, even
+        #    with a single entry.
+        for k, v in children.items():
+            if isinstance(v, list):
+                for i, item in enumerate(v, start=1):
+                    elem.append(_build_element(_make_pp_tag(k, i), item))
+            elif k in _ALWAYS_LIST_AS_INDEXED:
+                elem.append(_build_element(_make_pp_tag(k, 1), v))
+            else:
+                elem.append(_build_element(_make_pp_tag(k), v))
+
+        return elem
+
+    # Fallback: stringify.
+    elem.text = str(value)
+    return elem
+
+
+def dict_to_upfv2(upfdict: Mapping[str, Any], version: str) -> str:
+    """Serialise a parsed UPF dictionary back to UPF v2 (XML) text.
+
+    Parameters
+    ----------
+    upfdict
+        Mapping in the shape produced by :func:`upfv2contents_to_dict`.
+    version
+        UPF version string to record on the root ``<UPF version="...">``.
+
+    Returns
+    -------
+    str
+        A complete UPF v2 file ready to be written to disk.
+    """
+    root = ElementTree.Element("UPF", attrib={"version": str(version)})
+    for k, v in upfdict.items():
+        if isinstance(v, list):
+            for i, item in enumerate(v, start=1):
+                root.append(_build_element(_make_pp_tag(k, i), item))
+        elif k in _ALWAYS_LIST_AS_INDEXED:
+            root.append(_build_element(_make_pp_tag(k, 1), v))
+        else:
+            root.append(_build_element(_make_pp_tag(k), v))
+
+    ElementTree.indent(root, space="  ")
+    body = ElementTree.tostring(root, encoding="unicode")
+    return body + "\n"

--- a/src/upf_tools/v2.py
+++ b/src/upf_tools/v2.py
@@ -35,9 +35,7 @@ def block_to_dict(element: ElementTree.Element) -> OrderedDict[str, Any]:
 
     :return: a (possibly nested) dict
     """
-    result = {
-        k.lower(): sanitise(v) for k, v in element.attrib.items() if k not in _ARRAY_ATTRS
-    }
+    result = {k.lower(): sanitise(v) for k, v in element.attrib.items() if k not in _ARRAY_ATTRS}
 
     # Manually adding n information if it is missing
     if element.tag.startswith("PP_CHI") and "n" not in result and "label" in result:

--- a/src/upf_tools/v2.py
+++ b/src/upf_tools/v2.py
@@ -93,13 +93,15 @@ def _format_array(arr: np.ndarray) -> str:
 
     The result is wrapped at ``_DEFAULT_COLUMNS`` values per line to
     match the QE convention.
+
+    :param arr: array of floats to format
+    :returns: a string containing the formatted array, prefixed and suffixed with newlines
     """
     flat = np.asarray(arr).ravel()
     # 17 significant digits guarantees lossless float64 round-trip (IEEE 754).
     parts = [f"{v: .17E}" for v in flat]
     lines = [
-        " ".join(parts[i : i + _DEFAULT_COLUMNS])
-        for i in range(0, len(parts), _DEFAULT_COLUMNS)
+        " ".join(parts[i : i + _DEFAULT_COLUMNS]) for i in range(0, len(parts), _DEFAULT_COLUMNS)
     ]
     return "\n" + "\n".join(lines) + "\n"
 
@@ -142,6 +144,10 @@ def _build_element(tag: str, value: Any) -> ElementTree.Element:
     * ``Mapping`` -> attributes from non-``content`` keys; nested dicts/lists
       become child elements; a ``content`` key (if present) becomes the text
       of *this* element. Lists become numbered children.
+
+    :param tag: tag name to give the new element
+    :param value: parsed value to serialise
+    :returns: a new :class:`xml.etree.ElementTree.Element`
     """
     elem = ElementTree.Element(tag)
 
@@ -204,17 +210,9 @@ def _build_element(tag: str, value: Any) -> ElementTree.Element:
 def dict_to_upfv2(upfdict: Mapping[str, Any], version: str) -> str:
     """Serialise a parsed UPF dictionary back to UPF v2 (XML) text.
 
-    Parameters
-    ----------
-    upfdict
-        Mapping in the shape produced by :func:`upfv2contents_to_dict`.
-    version
-        UPF version string to record on the root ``<UPF version="...">``.
-
-    Returns
-    -------
-    str
-        A complete UPF v2 file ready to be written to disk.
+    :param upfdict: mapping in the shape produced by :func:`upfv2contents_to_dict`
+    :param version: UPF version string to record on the root ``<UPF version="...">``
+    :returns: a complete UPF v2 file ready to be written to disk
     """
     root = ElementTree.Element("UPF", attrib={"version": str(version)})
     for k, v in upfdict.items():

--- a/tests/test_upfdict.py
+++ b/tests/test_upfdict.py
@@ -1,6 +1,7 @@
 """Testing the :class:`UPFDict` class."""
 
 import pytest
+from packaging.version import Version
 
 from upf_tools import UPFDict
 
@@ -40,3 +41,27 @@ class TestUPFDictMethods:
                 upf_instance.to_ld1_input()
             else:
                 upf_instance.to_oncvpsp_input()
+
+    def test_to_str_roundtrip(self, upf_instance):
+        """Round-trip: ``read -> to_str -> from_str`` yields an equal :class:`UPFDict`.
+
+        Only v2 (XML) is supported on write; v1 fixtures raise
+        :class:`NotImplementedError` and are skipped.
+        """
+        if upf_instance.version < Version("2.0.0"):
+            with pytest.raises(NotImplementedError):
+                upf_instance.to_str()
+            pytest.skip("v1 writing not yet implemented")
+        text = upf_instance.to_str()
+        assert text.startswith("<UPF")
+        reparsed = UPFDict.from_str(text)
+        assert upf_instance == reparsed
+
+    def test_to_upf_writes_file(self, upf_instance, tmp_path):
+        """``to_upf`` writes a file that re-parses to an equal :class:`UPFDict`."""
+        if upf_instance.version < Version("2.0.0"):
+            pytest.skip("v1 writing not yet implemented")
+        out = upf_instance.to_upf(tmp_path / "out.upf")
+        assert out.is_file()
+        reparsed = UPFDict.from_upf(out)
+        assert upf_instance == reparsed

--- a/tests/test_upfdict.py
+++ b/tests/test_upfdict.py
@@ -47,7 +47,7 @@ class TestUPFDictMethods:
         if upf_instance.version < Version("2.0.0"):
             with pytest.raises(NotImplementedError):
                 upf_instance.to_str()
-            pytest.skip("v1 writing not yet implemented")
+            return
         text = upf_instance.to_str()
         assert text.startswith("<UPF")
         reparsed = UPFDict.from_str(text)

--- a/tests/test_upfdict.py
+++ b/tests/test_upfdict.py
@@ -43,11 +43,7 @@ class TestUPFDictMethods:
                 upf_instance.to_oncvpsp_input()
 
     def test_to_str_roundtrip(self, upf_instance):
-        """Round-trip: ``read -> to_str -> from_str`` yields an equal :class:`UPFDict`.
-
-        Only v2 (XML) is supported on write; v1 fixtures raise
-        :class:`NotImplementedError` and are skipped.
-        """
+        """Test that ``read -> to_str -> from_str`` yields an equal :class:`UPFDict`."""
         if upf_instance.version < Version("2.0.0"):
             with pytest.raises(NotImplementedError):
                 upf_instance.to_str()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"


### PR DESCRIPTION
Adds write-side support for UPF v2 (XML) pseudopotential files, complementing the existing read-side parser:

- `UPFDict.to_str()` serialises a parsed dict back to UPF v2 text; raises `NotImplementedError` for v1.
- `UPFDict.to_upf(path)` writes the result to disk.
- New `dict_to_upfv2` helper in `v2.py` inverts `block_to_dict`, reconstructing `PP_<NAME>` tags, numbered `.1`/`.2` children, `type/size/columns` attribs on numeric arrays, and using 17-significant-digit scientific notation for lossless float64 round-trip.
- Tests round-trip every fixture through `read → to_str → from_str` (and `to_upf → from_upf`) and assert equality; v1 fixtures assert `NotImplementedError`.